### PR TITLE
No shell and no home for gobgp user

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,8 @@ group node['gobgp']['group']
 
 user user do
   gid group
+  shell '/sbin/nologin'
+  manage_home false  
 end
 
 # Create the configuration file


### PR DESCRIPTION
Since the user is created just to run gobgpd, it does not need a shell nor a home directory.