### PR TITLE
2.2.0

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -13,7 +13,7 @@
 driver:
   name: ec2
   instance_type: t2.micro
-  associate_public_ip: true
+  associate_public_ip: false
   iam_profile_name: test-kitchen
   region: <%= ENV['AWS_REGION'] || 'us-west-2' %>
   tags:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default['gobgp']['binary']['checksum'] = '912b28827966c175cf0adea1f8085df40a8556
 default['gobgp']['user'] = 'gobgpd'
 default['gobgp']['group'] = 'gobgpd'
 default['gobgp']['config_file'] = '/etc/gobgpd.conf'
+default['gobgp']['environment_file'] = '/etc/sysconfig/gobgpd'
 
 default['gobgp']['config'] = ::Mash.new(
   "global":             {

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configure gobgp'
 long_description 'Installs/Configure gobgp'
 issues_url       'https://github.com/criteo-cookbooks/gobgp/issues'
 source_url       'https://github.com/criteo-cookbooks/gobgp'
-version          '2.1.0'
+version          '2.2.0'
 supports         'centos'
 
 depends          'ark'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,8 +55,9 @@ systemd_service 'gobgpd' do
     group                group
     ambient_capabilities 'CAP_NET_BIND_SERVICE'
     exec_start_pre       "#{cmd} -d"
-    exec_start           cmd
+    exec_start           "#{cmd} $OPTIONS"
     exec_reload          '/bin/kill -HUP $MAINPID'
+    environment_file     node['gobgp']['environment_file']
   end
   install do
     wanted_by 'multi-user.target'


### PR DESCRIPTION
- No longer expose public IP during Kitchen tests 
- Add possibilty to add options to gobgpd 